### PR TITLE
feat(request-list): clear requests on navigation with optional persistence toggle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ucan-chrome-ext",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ucan-chrome-ext",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "ISC",
       "devDependencies": {
         "@emotion/react": "^11.11.4",

--- a/src/RequestList.tsx
+++ b/src/RequestList.tsx
@@ -1,11 +1,13 @@
 import { Request } from "./types"
-import { CAR} from "@ucanto/core"
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
 import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
+import Box from '@mui/material/Box';
+import Switch from '@mui/material/Switch';
+import FormControlLabel from '@mui/material/FormControlLabel';
 import { isCarRequest, messageFromRequest } from "./util";
 function RequestEntry({ request, selectedRequest, selectRequest } : {request: Request, selectedRequest: Request | null, selectRequest: (request: Request) => void}) {
   const message = messageFromRequest(request)
@@ -17,10 +19,16 @@ function RequestEntry({ request, selectedRequest, selectRequest } : {request: Re
   )
 }
 
-function RequestList({ requests, selectedRequest, selectRequest} : { requests: Request[], selectedRequest: Request | null, selectRequest: (request: Request) => void }) {
+function RequestList({ requests, selectedRequest, selectRequest, persistOnReload, setPersistOnReload} : { requests: Request[], selectedRequest: Request | null, selectRequest: (request: Request) => void, persistOnReload: boolean, setPersistOnReload: (value:boolean) => void }) {
   const requestItems = requests.filter(isCarRequest).map(request => <RequestEntry selectedRequest={selectedRequest} selectRequest={selectRequest} request={request} />)
   return (
     <TableContainer sx={{height: "100%", overflowY: "scroll"}}>
+    <Box sx={{ display: 'flex', justifyContent: 'flex-end', px: 2, py: 1 }}>
+      <FormControlLabel
+        control={<Switch checked={persistOnReload} onChange={(e) => setPersistOnReload(e.target.checked)} />}
+        label="Persist across reloads"
+      />
+    </Box>
     <Table
       stickyHeader
       aria-labelledby="tableTitle"


### PR DESCRIPTION
Description:
- Add “Persist across reloads” switch in `RequestList` to control request persistence
- Persist preference in `localStorage` under `persistOnReload`
- Clear requests and selection on `chrome.devtools.network.onNavigated` when persistence is disabled
- Pass toggle state/handler from `App` to `RequestList`