### PR TITLE
feat(request-status): add request status indicator

### DIFF
--- a/src/RequestList.tsx
+++ b/src/RequestList.tsx
@@ -7,10 +7,57 @@ import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import { isCarRequest, messageFromRequest } from "./util";
+import FiberManualRecordIcon from '@mui/icons-material/FiberManualRecord';
+
+function getRequestStatus(request: Request) {
+  const httpStatus = request.response.status;
+  const isHttpSuccess = httpStatus >= 200 && httpStatus < 300;
+  const isHttpError = httpStatus >= 400;
+  
+  const message = messageFromRequest(request);
+  let hasReceiptError = false;
+  
+  if (typeof message !== 'string' && message.receipts.size > 0) {
+    for (const receipt of message.receipts.values()) {
+      if (receipt.out.error !== undefined) {
+        hasReceiptError = true;
+        break;
+      }
+    }
+  }
+  
+  if (isHttpError || hasReceiptError) {
+    return 'error';
+  } else if (isHttpSuccess && !hasReceiptError) {
+    return 'success';
+  } else {
+    return 'pending';
+  }
+}
+
 function RequestEntry({ request, selectedRequest, selectRequest } : {request: Request, selectedRequest: Request | null, selectRequest: (request: Request) => void}) {
   const message = messageFromRequest(request)
+  const status = getRequestStatus(request);
+  
+  const getStatusColor = (status: string) => {
+    switch (status) {
+      case 'success': return '#4caf50';
+      case 'error': return '#f44336';
+      case 'pending': return '#ff9800';
+      default: return '#9e9e9e';
+    }
+  };
+
   return (
     <TableRow onClick={() => selectRequest(request)} hover selected={request === selectedRequest}>
+      <TableCell>
+        <FiberManualRecordIcon 
+          sx={{ 
+            color: getStatusColor(status), 
+            fontSize: 16 
+          }} 
+        />
+      </TableCell>
       <TableCell>{request.request.url}</TableCell>
       <TableCell>{ typeof message === 'string' ? message : message.invocations.flatMap((invocation) => invocation.capabilities.map((capability => capability.can))).join(", ")}</TableCell>
     </TableRow>
@@ -27,6 +74,7 @@ function RequestList({ requests, selectedRequest, selectRequest} : { requests: R
       size={'medium'}
     >
       <TableHead>
+        <TableCell>Status</TableCell>
         <TableCell>URL</TableCell>
         <TableCell>Capabilities</TableCell>
       </TableHead>


### PR DESCRIPTION
Changes:
- Add status indicator dots (green/red/yellow) to RequestList and RequestInspector components
- Green dot: Successful requests (HTTP 2xx status + no receipt errors)
- Red dot: Failed requests (HTTP 4xx/5xx status or receipt errors)
- Yellow dot: Pending/unknown status
- Status column added to RequestList table
- Status indicator displayed in RequestInspector header

Closes #15 