### PR TITLE
Add Firefox support using polyfill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,16 @@
 {
   "name": "ucan-chrome-ext",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ucan-chrome-ext",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "ISC",
+      "dependencies": {
+        "webextension-polyfill": "^0.12.0"
+      },
       "devDependencies": {
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.5",
@@ -16,6 +19,7 @@
         "@types/chrome": "^0.0.193",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
+        "@types/webextension-polyfill": "^0.12.3",
         "@ucanto/core": "^10.0.1",
         "@ucanto/transport": "^9.1.1",
         "browser-sync": "^2.27.10",
@@ -4788,6 +4792,13 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "dev": true
+    },
+    "node_modules/@types/webextension-polyfill": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/@types/webextension-polyfill/-/webextension-polyfill-0.12.3.tgz",
+      "integrity": "sha512-F58aDVSeN/MjUGazXo/cPsmR76EvqQhQ1v4x23hFjUX0cfAJYE+JBWwiOGW36/VJGGxoH74sVlRIF3z7SJCKyg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.5.10",
@@ -19064,6 +19075,12 @@
       "dependencies": {
         "minimalistic-assert": "^1.0.0"
       }
+    },
+    "node_modules/webextension-polyfill": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.12.0.tgz",
+      "integrity": "sha512-97TBmpoWJEE+3nFBQ4VocyCdLKfw54rFaJ6EVQYLBCXqCIpLSZkwGgASpv4oPt9gdKCJ80RJlcmNzNn008Ag6Q==",
+      "license": "MPL-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -10,9 +10,14 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "@emotion/react": "^11.11.4",
+    "@emotion/styled": "^11.11.5",
+    "@mui/icons-material": "^5.15.20",
+    "@mui/material": "^5.15.20",
     "@types/chrome": "^0.0.193",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
+    "@types/webextension-polyfill": "^0.12.3",
     "@ucanto/core": "^10.0.1",
     "@ucanto/transport": "^9.1.1",
     "browser-sync": "^2.27.10",
@@ -27,10 +32,9 @@
     "typescript": "^4.7.4",
     "webpack": "^5.73.0",
     "webpack-cli": "^4.10.0",
-    "webpack-dev-server": "^4.9.3",
-    "@emotion/react": "^11.11.4",
-    "@emotion/styled": "^11.11.5",
-    "@mui/icons-material": "^5.15.20",
-    "@mui/material": "^5.15.20"
+    "webpack-dev-server": "^4.9.3"
+  },
+  "dependencies": {
+    "webextension-polyfill": "^0.12.0"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { Request } from './types'
 import RequestList from "./RequestList"
 import RequestInspector from "./RequestInspector";
 import Box from '@mui/material/Box'
+import "webextension-polyfill";
 
 type SetAction = {
   action: "set",
@@ -33,21 +34,21 @@ function App() {
   useEffect(() => {
     let ignore = false
     dispatch({action: "set", requests: []})
-    chrome.devtools.network.getHAR((harLog) => {
+    browser.devtools.network.getHAR().then((harLog: any) => {
       if (!ignore) {
-        dispatch({ action: "set", requests: harLog.entries})
+        dispatch({ action: "set", requests: harLog.entries })
       }
-    })
+    });
     return () => {
       ignore = true
     }
   }, [])
   
   useEffect(() => {
-    const listener = (request : chrome.devtools.network.Request) => { dispatch({action: "increment", request}) }
-    chrome.devtools.network.onRequestFinished.addListener(listener)
+    const listener = (request : any) => { dispatch({action: "increment", request}) }
+    browser.devtools.network.onRequestFinished.addListener(listener)
     return () => {
-      chrome.devtools.network.onRequestFinished.removeListener(listener)
+      browser.devtools.network.onRequestFinished.removeListener(listener)
     }
   })
 

--- a/src/RequestInspector.tsx
+++ b/src/RequestInspector.tsx
@@ -228,7 +228,7 @@ function ResponseDisplay({request} : { request: Request}) {
   useEffect(() => {
     let ignore = false
     if (isChromeRequest(request)) {
-      request.getContent((content, encoding) => {
+      request.getContent((content: string, encoding: string) => {
         if (!ignore) {
           let decoded = content
           if (encoding == 'base64') {

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,0 +1,1 @@
+declare const browser: typeof import('webextension-polyfill');

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,3 @@
-chrome.devtools.panels.create('UCAN Requests', '', 'panel.html', () => {
-  console.log('user switched to this panel');
-});
+import "webextension-polyfill";
+
+browser.devtools.panels.create('UCAN Requests', '', 'panel.html');

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,3 @@
-export type Request = chrome.devtools.network.Request | chrome.devtools.network.HAREntry
+export type Request = any;
 
-export const isChromeRequest = (request: Request) : request is chrome.devtools.network.Request => (typeof (request as chrome.devtools.network.Request).getContent === 'function')
+export const isChromeRequest = (request: Request) : boolean => (typeof (request as any).getContent === 'function')

--- a/src/util.ts
+++ b/src/util.ts
@@ -33,7 +33,7 @@ export const bigIntSafe = (_ : any, value : any) => typeof value === 'bigint' ? 
 export const shortString = (st : string, n: number) => st.length > n ? st.substring(0, n) + '...' : st
 
 export function isCarRequest(request : Request) {
-  return request.request.headers.some((header) => header.name.toLowerCase() == 'content-type' && header.value == CAR.contentType)
+  return request.request.headers.some((header: { name: string; value: string }) => header.name.toLowerCase() == 'content-type' && header.value == CAR.contentType)
 }
 
 export function formatError(error: any): string {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,8 @@
 {
   "compilerOptions": {
       "strict": true,
-      "lib": [
-        "dom",
-        "dom.iterable",
-        "esnext"
-      ],
+      "types": ["webextension-polyfill"],
+      "lib": ["dom", "esnext", "webworker"],
       "module": "esnext",
       "moduleResolution": "node",
       "target": "es6",


### PR DESCRIPTION

This PR introduces a polyfill for the WebExtension API by adding `webextension-polyfill` to the project. The polyfill is imported in key entry points (`main.ts`, `App.tsx`) to ensure consistent cross-browser compatibility, especially for Firefox support, and also  a global type declaration for the browser namespace is added in `globals.d.ts` to enable proper TS support for the polyfilled API.
<img width="1378" height="825" alt="Screenshot 2025-08-09 at 23 27 56" src="https://github.com/user-attachments/assets/0d55e9bf-5b8f-489d-b7df-14d67342b149" />


closes https://github.com/storacha/ucan-see-my-request/issues/19