### PR TITLE
feat: add save buttons for request and response CAR files

### DIFF
--- a/src/RequestInspector.tsx
+++ b/src/RequestInspector.tsx
@@ -8,7 +8,8 @@ import Box from '@mui/material/Box';
 import Card from '@mui/material/Card'
 import CardHeader from '@mui/material/CardHeader';
 import CardContent from '@mui/material/CardContent';
-import {shortString, bigIntSafe, messageFromRequest, decodeMessage, formatError} from './util'
+import Button from '@mui/material/Button';
+import {shortString, bigIntSafe, messageFromRequest, decodeMessage, formatError, saveCarToFile, isCarRequest} from './util'
 import Accordion from '@mui/material/Accordion';
 import AccordionSummary from '@mui/material/AccordionSummary';
 import AccordionDetails from '@mui/material/AccordionDetails';
@@ -208,12 +209,56 @@ function MessageDisplay({message} : { message : AgentMessage}) {
 
 function RequestDisplay({request} : { request: Request}) {
   const message = messageFromRequest(request)
-  return <div>{typeof message == 'string' ? message : <MessageDisplay message={message}/>}</div>
+  
+  const handleSaveRequest = () => {
+    if (request.request.postData?.text) {
+      saveCarToFile(request.request.postData.text, 'request', request.request.url);
+    }
+  };
+
+  return (
+    <div>
+      {isCarRequest(request) && (
+        <Box sx={{ mb: 2 }}>
+          <Button 
+            variant="contained" 
+            onClick={handleSaveRequest}
+            disabled={!request.request.postData?.text}
+          >
+            Save Request CAR
+          </Button>
+        </Box>
+      )}
+      {typeof message == 'string' ? message : <MessageDisplay message={message}/>}
+    </div>
+  );
 }
 
-function ResponseBodyDisplay({ body } : {body : string}) {
+function ResponseBodyDisplay({ body, request } : {body : string, request: Request}) {
   const message = decodeMessage(body)
-  return <div>{typeof message == 'string' ? message : <MessageDisplay message={message}/>}</div>
+  
+  const handleSaveResponse = () => {
+    if (body) {
+      saveCarToFile(body, 'response', request.request.url);
+    }
+  };
+
+  return (
+    <div>
+      {isCarRequest(request) && (
+        <Box sx={{ mb: 2 }}>
+          <Button 
+            variant="contained" 
+            onClick={handleSaveResponse}
+            disabled={!body}
+          >
+            Save Response CAR
+          </Button>
+        </Box>
+      )}
+      {typeof message == 'string' ? message : <MessageDisplay message={message}/>}
+    </div>
+  );
 }
 
 function ResponseDisplay({request} : { request: Request}) {
@@ -242,7 +287,7 @@ function ResponseDisplay({request} : { request: Request}) {
       ignore = true
     }
   }, [request])
-  return <ResponseBodyDisplay body={body} />
+  return <ResponseBodyDisplay body={body} request={request} />
 }
 
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -43,3 +43,23 @@ export function formatError(error: any): string {
     return String(error); // Fallback for non-JSON errors
   }
 }
+
+export function saveCarToFile(carData: string, prefix: string, url: string) {
+  const uint8Array = convertBinaryStringToUint8Array(carData);
+  const blob = new Blob([uint8Array], { type: 'application/vnd.ipld.car' });
+
+  const blobUrl = URL.createObjectURL(blob);
+
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  
+  const urlPart = url.replace(/[^a-zA-Z0-9]/g, '_').slice(0, 30);
+  
+  const a = document.createElement('a');
+  a.href = blobUrl;
+  a.download = `${prefix}_${timestamp}_${urlPart}.car`;
+  document.body.appendChild(a);
+  a.click();
+  
+  document.body.removeChild(a);
+  URL.revokeObjectURL(blobUrl);
+}


### PR DESCRIPTION
This PR adds functionality to save CAR files for both requests and responses, addressing issue #17 . Users can now download CAR files directly from the UI for further analysis or debugging.

## Changes
- Add Save Request CAR button to the request panel
- Add Save Response CAR button to the response panel
- Implement `saveCarToFile` utility function for handling CAR file downloads
- Add proper file naming with timestamps and URL-based names
- Show/hide buttons based on request content type
- Handle disabled states when no data is available